### PR TITLE
HexDocs: improve package documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
         path: |
           _build
           deps
-        key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ matrix.otp }}-${{ matrix.elixir }}-
     - name: Install and compile dependencies
       if: steps.cache-deps.outputs.cache-hit != 'true'
       run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,36 @@ on:
       - main
 
 jobs:
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+
+    env:
+      MIX_ENV: dev
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Elixir
+      id: setup-beam
+      uses: erlef/setup-beam@v1
+      with:
+        version-file: '.tool-versions'
+        version-type: 'strict'
+    - name: Cache dependencies
+      id: cache-deps
+      uses: actions/cache@v4
+      with:
+        path: |
+          _build
+          deps
+        key: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+    - name: Install and compile dependencies
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      run: mix do deps.get --only ${{ env.MIX_ENV }}, deps.compile
+    - name: Generate documentation
+      run: mix docs --warnings-as-errors
+
   test:
     name: Tests [Elixir ${{ matrix.elixir }} / OTP ${{ matrix.otp }}]
     runs-on: ubuntu-latest

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Deputy.MixProject do
       main: "readme",
       source_ref: "v#{@version}",
       source_url: @source_url,
-      extras: ["README.md", "LICENSE"]
+      extras: ["README.md", "CHANGELOG.md", "LICENSE"]
     ]
   end
 
@@ -58,6 +58,7 @@ defmodule Deputy.MixProject do
       licenses: ["MIT"],
       links: %{
         "GitHub" => @source_url,
+        "Changelog" => "https://hexdocs.pm/humaans/changelog.html",
         "Sponsor" => "https://github.com/sponsors/sgerrand"
       },
       files: ~w(lib LICENSE mix.exs README.md)

--- a/mix.exs
+++ b/mix.exs
@@ -42,8 +42,10 @@ defmodule Deputy.MixProject do
 
   defp docs do
     [
+      main: "readme",
       source_ref: "v#{@version}",
-      source_url: @source_url
+      source_url: @source_url,
+      extras: ["README.md", "LICENSE"]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -19,6 +19,7 @@ defmodule Deputy.MixProject do
 
       # Docs
       name: "Deputy",
+      source_url: @source_url,
       homepage_url: @source_url,
       docs: docs()
     ]


### PR DESCRIPTION
💁 These changes enhance the existing `ex_doc` configuration to improve the presentation on [HexDocs](https://hexdocs.pm/):
- name the project via `docs.main`
- set the source and homepage URLs
- add the README and CHANGELOG via `docs.extras[]`

I've also added another job to the existing CI workflow to validate that the package documentation will be generated without errors or warnings.