### PR TITLE
CI: Expublish runs tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_call:
   pull_request:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,7 @@ on:
         required: true
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-    secrets: inherit
-
   publish:
-    needs: [ci]
     name: Build and publish to hex.pm
     runs-on: ubuntu-22.04
     env:
@@ -57,4 +52,4 @@ jobs:
       run: echo -e "${{ inputs.changes }}" > RELEASE.md
 
     - name: Bump version, generate changelog, push to git, publish on hex.pm
-      run: mix expublish.${{ inputs.version }} --branch=main --disable-test
+      run: mix expublish.${{ inputs.version }} --branch=main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,7 @@ jobs:
         git config --global user.name "github-actions[bot]"
 
     - name: Setup Elixir
+      id: setup-beam
       uses: erlef/setup-elixir@v1
       with:
         version-file: '.tool-versions'
@@ -42,8 +43,8 @@ jobs:
       uses: actions/cache@v4
       with:
         path: deps
-        key: ${{ runner.os }}-publish-mix-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
-        restore-keys: ${{ runner.os }}-publish-mix-${{ matrix.otp }}-${{ matrix.elixir }}-
+        key: ${{ runner.os }}-publish-mix-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: ${{ runner.os }}-publish-mix-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
 
     - name: Install deps
       run: mix deps.get


### PR DESCRIPTION
💁 The jobs in the CI workflow exist as guards to code being merged. Running them again from the Publish workflow is overkill when Expublish can run the test suite itself. These changes enable that to occur.