### PR TITLE
Review and report Mix dependencies

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -1,0 +1,23 @@
+name: "Review and Report Dependencies"
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request: {}
+
+# The API requires write permission on the repository to submit dependencies
+permissions:
+  contents: write
+
+jobs:
+  report_mix_deps:
+    name: "Report Mix Dependencies"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/mix-dependency-submission@v1
+        with:
+          install-deps: true
+      - uses: actions/dependency-review-action@v4
+        if: "${{ github.event_name == 'pull_request' }}"


### PR DESCRIPTION
💁 These changes introduce a new workflow to review dependencies in this project, with the initial job focused on Mix:
- submitting Mix dependencies to the GitHub Dependency Submission API
- reviewing Mix dependencies for potential vulnerabilities and invalid licenses

The first part unlocks some interesting data:
- :closed_lock_with_key: Dependabot alerts and security updates — including transitive deps
- :chart_with_upwards_trend: Full dependency graph visibility — even without lockfiles
- :eyes: Dependency Review — see what changed in PRs
- :receipt: Helps with auditing and compliance for third-party packages

The second part requires a GitHub Advanced Security license, which is freely available for public repositories and could be useful.