### PR TITLE
Actions: Reduce permissions for workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   required:
     name: Required

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ on:
         description: Specify an entry for the changelog
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   publish:
     name: Build and publish to hex.pm


### PR DESCRIPTION
💁 In the spirit of applying least privilege to the permissions available to GitHub Actions, these changes set minimal permissions for workflow jobs that don't require permissions beyond being able to clone and checkout code, and elevated permissions for those which need to do more.