### PR TITLE
Elixir v1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,13 +56,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        elixir: ['1.15', '1.16', '1.17', '1.18']
+        elixir: ['1.15', '1.16', '1.17', '1.18', '1.19']
         otp: ['25', '26', '27']
         exclude:
           - elixir: '1.15'
             otp: '27'
           - elixir: '1.16'
             otp: '27'
+          - elixir: '1.19'
+            otp: '25'
         include:
           - elixir: '1.18'
             otp: '27'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18-otp-27
+elixir 1.19-otp-27
 erlang 27.2


### PR DESCRIPTION
💁 These changes introduce Elixir version 1.19:
- update the version used for local development
- adds this version to the test matrix used in continuous integration

📖 See the [release notes](https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/) for more information on this release.