### PR TITLE
Erlang v28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,20 @@ jobs:
       fail-fast: false
       matrix:
         elixir: ['1.15', '1.16', '1.17', '1.18', '1.19']
-        otp: ['25', '26', '27']
+        otp: ['25', '26', '27', '28']
         exclude:
           - elixir: '1.15'
             otp: '27'
+          - elixir: '1.15'
+            otp: '28'
           - elixir: '1.16'
             otp: '27'
+          - elixir: '1.16'
+            otp: '28'
+          - elixir: '1.17'
+            otp: '28'
+          - elixir: '1.18'
+            otp: '28'
           - elixir: '1.19'
             otp: '25'
         include:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19-otp-27
-erlang 27.2
+elixir 1.19-otp-28
+erlang 28.1


### PR DESCRIPTION
💁 These changes introduce Erlang/OTP version 28:
- update the version used for local development
- adds this version to the test matrix used in continuous integration

📖 See the [release notes](https://github.com/erlang/otp/releases/tag/OTP-28.1) for more information on this release.