### PR TITLE
build: add pre-commit hooks and project documentation

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,10 @@
+{
+  // Exclude generated/vendored directories and files managed by tooling
+  "ignores": ["RELEASE.md", ".claude/", "_build/", "deps/"],
+  "config": {
+    // Badge URLs and long code examples exceed 80 chars
+    "MD013": false,
+    // CHANGELOG repeats section names (## Added, ## Fixed) across versions
+    "MD024": false
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,23 @@ adheres to [Semantic Versioning](http://semver.org/).
 ## 0.3.0 - 2025-04-24
 
 ### Changes
-- Renamed exception modules for consistency
 
+- Renamed exception modules for consistency
 
 ## 0.2.1 - 2025-03-04
 
 ### Changes
-- Fixed changelog URL in package metadata
 
+- Fixed changelog URL in package metadata
 
 ## 0.2.0 - 2025-03-04
 
 ### Changes
+
 - Introduce centralised error types and handling functions.
 - Improve presentation of package documentation.
 - Update package metadata with additional links, etc.
 
-
 ## 0.1.0 - 2025-03-03
 
 Initial version. :rocket:
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development
+
+### Requirements
+
+- Elixir 1.19 / Erlang OTP 28.1 — managed via `asdf` (see `.tool-versions`)
+
+### Setup
+
+```shell
+bin/setup   # installs tooling (actionlint, lefthook, markdownlint) and git hooks
+mix setup   # installs Elixir dependencies
+```
+
+### Commands
+
+| Task | Command |
+| ---- | ------- |
+| Run all tests | `mix test` |
+| Run a single test | `mix test path/to/test_file.exs:line_number` |
+| Run a test file | `mix test path/to/test_file.exs` |
+| Format code | `mix format` |
+| Lint | `mix credo` |
+| Generate docs | `mix docs` |
+
+## Architecture
+
+Deputy is an Elixir client library for the Deputy workforce management REST API. It is organized as a thin HTTP client abstraction over resource-oriented API modules.
+
+### Core Layer
+
+- **`Deputy`** (`lib/deputy.ex`) — Entry point. Defines the `%Deputy{}` client struct (`base_url`, `api_key`, `http_client`) and the core `request/4` / `request!/4` functions that all resource modules call.
+- **`Deputy.Error`** (`lib/deputy/error.ex`) — Defines five error structs: `APIError`, `HTTPError`, `ParseError`, `ValidationError`, `RateLimitError`. The `from_response/1` function classifies HTTP responses into the appropriate type.
+- **`Deputy.HTTPClient.Behaviour`** — Single-callback behaviour (`request/1`) that makes the HTTP layer swappable. Default implementation uses `Req`; tests inject `Deputy.HTTPClient.Mock` via Mox.
+
+### Resource Modules
+
+Each module under `lib/deputy/` maps to a Deputy API domain: `Locations`, `Employees`, `Departments`, `Rosters`, `Timesheets`, `Sales`, `Utility`, `My`. All follow the same conventions:
+
+- Every public function has a regular variant returning `{:ok, data} | {:error, error}` and a bang variant (`list!/1`) that unwraps or raises.
+- Operations delegate to `Deputy.request/4` with the method, path, body, and params.
+- API endpoints are versioned: `v1` for most resources, `v2` for sales metrics; some management operations use `/api/management/v2/`.
+
+### Testing
+
+Tests live in `test/deputy/` mirroring the lib structure. `test_helper.exs` defines `Deputy.HTTPClient.Mock` and calls `Mox.verify_on_exit!/0`. Each test uses `expect(:request, fn ... end)` to control HTTP responses without network calls.
+
+## Code Style Guidelines
+
+- Use `@moduledoc` and `@doc` with examples for all public modules and functions.
+- Validate input with predefined lists; return `ValidationError` for bad types before making HTTP calls.
+- Organize modules hierarchically matching the API domain structure.
+- Handle all errors via pattern matching on `{:ok, _} | {:error, _}` tuples.
+
+## Git Flow
+
+- Branch naming: `feature-description-ticket-id`
+- PRs should include tests and documentation updates

--- a/README.md
+++ b/README.md
@@ -305,6 +305,30 @@ test "list employees error handling" do
 end
 ```
 
+## Development
+
+### Requirements
+
+- Elixir 1.19 / Erlang OTP 28.1 — managed via `asdf` (see `.tool-versions`)
+
+### Setup
+
+```shell
+bin/setup   # installs tooling (actionlint, lefthook, markdownlint) and git hooks
+mix setup   # installs Elixir dependencies
+```
+
+### Commands
+
+| Task | Command |
+| ---- | ------- |
+| Run all tests | `mix test` |
+| Run a single test | `mix test path/to/test_file.exs:line_number` |
+| Run a test file | `mix test path/to/test_file.exs` |
+| Format code | `mix format` |
+| Lint | `mix credo` |
+| Generate docs | `mix docs` |
+
 ## Documentation
 
 Detailed documentation can be found at <https://hexdocs.pm/deputy>.

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+brew install actionlint check-jsonschema lefthook markdownlint-cli2
+lefthook install

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,24 @@
+pre-commit:
+  parallel: true
+  commands:
+    mix-format:
+      glob: "*.{ex,exs}"
+      run: mix format --check-formatted
+    actionlint:
+      glob: ".github/workflows/*.yml"
+      run: actionlint {staged_files}
+    check-github-workflows:
+      glob: ".github/workflows/*.yml"
+      run: check-jsonschema --builtin-schema vendor.github-workflows {staged_files}
+    check-dependabot:
+      glob: ".github/dependabot.{yml,yaml}"
+      run: check-jsonschema --builtin-schema vendor.dependabot {staged_files}
+    check-release-please-config:
+      glob: "release-please-config.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json {staged_files}
+    check-release-please-manifest:
+      glob: ".release-please-manifest.json"
+      run: check-jsonschema --schemafile https://raw.githubusercontent.com/googleapis/release-please/main/schemas/manifest.json {staged_files}
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add lefthook pre-commit hooks for `mix format`, markdownlint, actionlint, and dependabot/release-please config validation
- Add `CLAUDE.md` with project guidance covering architecture, development setup, and code style conventions
- Add a Development section to `README.md` documenting requirements, setup steps (`bin/setup`, `mix setup`), and common commands