### PR TITLE
fix(test): remove unused test/support path from elixirc_paths

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,7 +50,6 @@ defmodule Deputy.MixProject do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp package do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove the `test/support` path from `elixirc_paths/1` in `mix.exs` — the directory does not exist, so the reference is dead code.

## Test plan

- [x] `mix test` passes