### PR TITLE
refactor(http_client): consolidate duplicate behaviour modules

### DIFF
--- a/lib/deputy/http_client/behaviour.ex
+++ b/lib/deputy/http_client/behaviour.ex
@@ -1,7 +1,0 @@
-defmodule Deputy.HTTPClient.Behaviour do
-  @moduledoc """
-  Behavior for HTTP clients used by Deputy
-  """
-
-  @callback request(keyword()) :: {:ok, map()} | {:error, any()}
-end

--- a/lib/deputy/http_client/req.ex
+++ b/lib/deputy/http_client/req.ex
@@ -2,7 +2,7 @@ defmodule Deputy.HTTPClient.Req do
   @moduledoc """
   HTTP client implementation using Req
   """
-  @behaviour Deputy.HTTPClient.Behaviour
+  @behaviour Deputy.HTTPClient
 
   alias Deputy.Error
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,5 @@
 ExUnit.start()
 
-Mox.defmock(Deputy.HTTPClient.Mock, for: Deputy.HTTPClient.Behaviour)
+Mox.defmock(Deputy.HTTPClient.Mock, for: Deputy.HTTPClient)
 
 Application.put_env(:deputy, :http_client, Deputy.HTTPClient.Mock)


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Remove `Deputy.HTTPClient.Behaviour` — it was an exact duplicate of `Deputy.HTTPClient`, with identical `@callback` and `@moduledoc`.
- Update `Deputy.HTTPClient.Req` to declare `@behaviour Deputy.HTTPClient` (the canonical module).
- Update `test/test_helper.exs` to mock for `Deputy.HTTPClient` instead of the now-removed `Deputy.HTTPClient.Behaviour`.

## Test plan

- [x] `mix test` passes
- [x] `mix credo --strict` passes