### PR TITLE
fix(error): read Retry-After header for rate limit errors

### DIFF
--- a/lib/deputy/error.ex
+++ b/lib/deputy/error.ex
@@ -119,6 +119,14 @@ defmodule Deputy.Error do
   based on the status code and response body structure.
   """
   @spec from_response(map()) :: t()
+  def from_response(%{status: 429, body: body, headers: headers}) do
+    %RateLimitError{
+      retry_after: get_retry_after_header(headers) || get_retry_after(body),
+      limit: get_rate_limit(body),
+      remaining: get_rate_remaining(body)
+    }
+  end
+
   def from_response(%{status: 429, body: body}) do
     %RateLimitError{
       retry_after: get_retry_after(body),
@@ -176,6 +184,21 @@ defmodule Deputy.Error do
       body: nil
     }
   end
+
+  defp get_retry_after_header(headers) when is_map(headers) do
+    case Map.get(headers, "retry-after") || Map.get(headers, "Retry-After") do
+      value when is_binary(value) ->
+        case Integer.parse(value) do
+          {seconds, ""} -> seconds
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp get_retry_after_header(_), do: nil
 
   defp get_retry_after(body) do
     case body do

--- a/lib/deputy/http_client/req.ex
+++ b/lib/deputy/http_client/req.ex
@@ -12,8 +12,8 @@ defmodule Deputy.HTTPClient.Req do
       {:ok, %{status: status, body: body}} when status in 200..299 ->
         {:ok, body}
 
-      {:ok, %{status: status, body: body}} ->
-        error = Error.from_response(%{status: status, body: body})
+      {:ok, %{status: status, body: body, headers: headers}} ->
+        error = Error.from_response(%{status: status, body: body, headers: headers})
         {:error, error}
 
       {:error, error} ->

--- a/test/deputy/error_test.exs
+++ b/test/deputy/error_test.exs
@@ -81,6 +81,32 @@ defmodule Deputy.ErrorTest do
       assert error.remaining == 0
     end
 
+    test "creates a RateLimitError for 429 status with Retry-After header" do
+      response = %{
+        status: 429,
+        body: %{},
+        headers: %{"retry-after" => "45"}
+      }
+
+      error = Error.from_response(response)
+
+      assert %RateLimitError{} = error
+      assert error.retry_after == 45
+    end
+
+    test "prefers Retry-After header over body field when both present" do
+      response = %{
+        status: 429,
+        body: %{"retry_after" => 60},
+        headers: %{"retry-after" => "30"}
+      }
+
+      error = Error.from_response(response)
+
+      assert %RateLimitError{} = error
+      assert error.retry_after == 30
+    end
+
     test "creates a RateLimitError for 429 status with camelCase" do
       response = %{
         status: 429,


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Update `Deputy.Error.from_response/1` to accept a `headers` key alongside `status` and `body` for 429 responses.
- When a `Retry-After` HTTP header is present, use its value (parsed as integer seconds) in preference over the response body's `retry_after` / `retryAfter` field.
- Update `Deputy.HTTPClient.Req` to include response headers when constructing the error map, so the header value is available.
- Add two tests: one verifying the header is read, one verifying the header takes precedence over the body field.

## Test plan

- [x] `mix test` passes
- [x] Existing 429 tests (body-only) still pass unchanged