### PR TITLE
refactor(types): tighten return type specs across all modules

### DIFF
--- a/lib/deputy.ex
+++ b/lib/deputy.ex
@@ -100,7 +100,7 @@ defmodule Deputy do
     * `%Deputy.Error.ParseError{}` - Failed to parse response
     * `%Deputy.Error.ValidationError{}` - Validation of request parameters failed
   """
-  @spec request(t(), atom(), String.t(), keyword()) :: {:ok, map()} | {:error, Error.t()}
+  @spec request(t(), atom(), String.t(), keyword()) :: {:ok, map() | list()} | {:error, Error.t()}
   def request(%__MODULE__{} = client, method, path, opts \\ []) do
     url = client.base_url <> path
 
@@ -131,7 +131,7 @@ defmodule Deputy do
       # client = Deputy.new(base_url: "https://test.deputy.com", api_key: "test-key")
       # locations = Deputy.request!(client, :get, "/api/v1/resource/Company")
   """
-  @spec request!(t(), atom(), String.t(), keyword()) :: map()
+  @spec request!(t(), atom(), String.t(), keyword()) :: map() | list()
   def request!(client, method, path, opts \\ []) do
     case request(client, method, path, opts) do
       {:ok, response} -> response

--- a/lib/deputy/departments.ex
+++ b/lib/deputy/departments.ex
@@ -36,7 +36,7 @@ defmodule Deputy.Departments do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
     Deputy.request(client, :put, "/api/v1/supervise/department", body: attrs)
   end
@@ -76,7 +76,7 @@ defmodule Deputy.Departments do
       {:ok, %{"success" => true}}
 
   """
-  @spec create_multiple(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create_multiple(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create_multiple(client, attrs) do
     Deputy.request(client, :put, "/api/v1/supervise/department/create/", body: attrs)
   end
@@ -91,7 +91,7 @@ defmodule Deputy.Departments do
       {:ok, [%{"Id" => 1, "OpunitName" => "Sales"}]}
 
   """
-  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def list(client) do
     Deputy.request(client, :get, "/api/v1/resource/OperationalUnit/")
   end
@@ -111,7 +111,7 @@ defmodule Deputy.Departments do
       {:ok, %{"success" => true}}
 
   """
-  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def delete(client, id) do
     Deputy.request(client, :delete, "/api/v1/resource/OperationalUnit/#{id}")
   end
@@ -136,7 +136,7 @@ defmodule Deputy.Departments do
       {:ok, %{"success" => true}}
 
   """
-  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, any()}
+  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def update(client, id, attrs) do
     Deputy.request(client, :post, "/api/v1/resource/OperationalUnit/#{id}", body: attrs)
   end
@@ -161,7 +161,7 @@ defmodule Deputy.Departments do
       {:ok, [%{"Id" => 1, "Employees" => [%{"Id" => 123, "FirstName" => "John"}]}]}
 
   """
-  @spec query(Deputy.t(), map()) :: {:ok, list(map())} | {:error, any()}
+  @spec query(Deputy.t(), map()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def query(client, query) do
     Deputy.request(client, :post, "/api/v1/resource/OperationalUnit/QUERY", body: query)
   end

--- a/lib/deputy/employees.ex
+++ b/lib/deputy/employees.ex
@@ -15,7 +15,7 @@ defmodule Deputy.Employees do
       {:ok, [%{"Id" => 1, "FirstName" => "John", "LastName" => "Doe"}]}
 
   """
-  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def list(client) do
     Deputy.request(client, :get, "/api/v1/supervise/employee")
   end
@@ -35,7 +35,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Id" => 1, "FirstName" => "John", "LastName" => "Doe"}}
 
   """
-  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/employee/#{id}")
   end
@@ -78,7 +78,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/employee", body: attrs)
   end
@@ -99,7 +99,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, any()}
+  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def update(client, id, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}", body: attrs)
   end
@@ -120,7 +120,8 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec add_location(Deputy.t(), integer(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec add_location(Deputy.t(), integer(), integer()) ::
+          {:ok, map()} | {:error, Deputy.Error.t()}
   def add_location(client, employee_id, company_id) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{employee_id}/assoc/#{company_id}")
   end
@@ -141,7 +142,8 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec remove_location(Deputy.t(), integer(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec remove_location(Deputy.t(), integer(), integer()) ::
+          {:ok, map()} | {:error, Deputy.Error.t()}
   def remove_location(client, employee_id, company_id) do
     Deputy.request(
       client,
@@ -165,7 +167,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec terminate(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec terminate(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def terminate(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}/terminate")
   end
@@ -185,7 +187,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec reactivate(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec reactivate(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def reactivate(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}/activate")
   end
@@ -205,7 +207,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def delete(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}/delete")
   end
@@ -225,7 +227,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec invite(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec invite(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def invite(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}/invite")
   end
@@ -251,7 +253,7 @@ defmodule Deputy.Employees do
       {:ok, %{"success" => true}}
 
   """
-  @spec set_award(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, any()}
+  @spec set_award(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def set_award(client, id, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/employee/#{id}/setAwardFromLibrary",
       body: attrs
@@ -273,7 +275,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Status" => "On Shift", "RosterID" => 123}}
 
   """
-  @spec get_shift_info(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get_shift_info(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_shift_info(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/empshiftinfo/#{id}")
   end
@@ -293,7 +295,7 @@ defmodule Deputy.Employees do
       {:ok, [%{"Id" => 123, "DateStart" => "2023-01-01", "DateEnd" => "2023-01-05"}]}
 
   """
-  @spec get_leave(Deputy.t(), integer()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_leave(Deputy.t(), integer()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_leave(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/leave/#{id}")
   end
@@ -330,7 +332,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec add_leave(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec add_leave(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def add_leave(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/leave/", body: attrs)
   end
@@ -350,7 +352,8 @@ defmodule Deputy.Employees do
       {:ok, [%{"Id" => 123, "Start" => %{"timestamp" => 1657001675}, "End" => %{"timestamp" => 1657001676}}]}
 
   """
-  @spec get_unavailability(Deputy.t(), integer()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_unavailability(Deputy.t(), integer()) ::
+          {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_unavailability(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/unavail/#{id}")
   end
@@ -385,7 +388,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec add_unavailability(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec add_unavailability(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def add_unavailability(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/unavail/", body: attrs)
   end
@@ -410,7 +413,7 @@ defmodule Deputy.Employees do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec add_journal(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec add_journal(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def add_journal(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/journal", body: attrs)
   end
@@ -430,7 +433,7 @@ defmodule Deputy.Employees do
       {:ok, %{"AgreedHours" => 40.0}}
 
   """
-  @spec get_agreed_hours(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get_agreed_hours(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_agreed_hours(client, id) do
     Deputy.request(client, :get, "/api/management/v2/agreed_hour/#{id}")
   end

--- a/lib/deputy/error.ex
+++ b/lib/deputy/error.ex
@@ -10,6 +10,7 @@ defmodule Deputy.Error do
           Deputy.Error.APIError.t()
           | Deputy.Error.HTTPError.t()
           | Deputy.Error.ParseError.t()
+          | Deputy.Error.RateLimitError.t()
           | Deputy.Error.ValidationError.t()
 
   defmodule APIError do

--- a/lib/deputy/locations.ex
+++ b/lib/deputy/locations.ex
@@ -258,7 +258,7 @@ defmodule Deputy.Locations do
       {:ok, %{"success" => true}}
 
   """
-  @spec archive(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec archive(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def archive(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/company/#{id}/archive")
   end
@@ -278,7 +278,7 @@ defmodule Deputy.Locations do
       {:ok, %{"success" => true}}
 
   """
-  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec delete(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def delete(client, id) do
     Deputy.request(client, :post, "/api/v1/supervise/company/#{id}/delete")
   end
@@ -318,7 +318,7 @@ defmodule Deputy.Locations do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
     Deputy.request(client, :put, "/api/v1/resource/Company", body: attrs)
   end
@@ -339,7 +339,7 @@ defmodule Deputy.Locations do
       {:ok, %{"success" => true}}
 
   """
-  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, any()}
+  @spec update(Deputy.t(), integer(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def update(client, id, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/company/#{id}", body: attrs)
   end
@@ -385,7 +385,7 @@ defmodule Deputy.Locations do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create_workplace(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create_workplace(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create_workplace(client, attrs) do
     Deputy.request(client, :post, "/api/v1/my/setup/addNewWorkplace", body: attrs)
   end
@@ -405,7 +405,7 @@ defmodule Deputy.Locations do
       {:ok, %{"Id" => 1, "CompanyName" => "Test Company"}}
 
   """
-  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get(client, id) do
     Deputy.request(client, :get, "/api/v1/my/location/#{id}")
   end

--- a/lib/deputy/my.ex
+++ b/lib/deputy/my.ex
@@ -15,7 +15,7 @@ defmodule Deputy.My do
       {:ok, %{"Id" => 1, "FirstName" => "John", "LastName" => "Doe"}}
 
   """
-  @spec me(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec me(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def me(client) do
     Deputy.request(client, :get, "/api/v1/me")
   end
@@ -30,7 +30,7 @@ defmodule Deputy.My do
       {:ok, %{"locations" => [%{"Id" => 1, "Name" => "Main Office"}]}}
 
   """
-  @spec setup(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec setup(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def setup(client) do
     Deputy.request(client, :get, "/api/v1/my/setup")
   end
@@ -45,7 +45,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "Name" => "Main Office"}]}
 
   """
-  @spec locations(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec locations(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def locations(client) do
     Deputy.request(client, :get, "/api/v1/my/location")
   end
@@ -65,7 +65,7 @@ defmodule Deputy.My do
       {:ok, %{"Id" => 1, "Name" => "Main Office"}}
 
   """
-  @spec location(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec location(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def location(client, id) do
     Deputy.request(client, :get, "/api/v1/my/location/#{id}")
   end
@@ -80,7 +80,7 @@ defmodule Deputy.My do
       {:ok, %{"Street1" => "123 Main St", "City" => "New York"}}
 
   """
-  @spec contact_address(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec contact_address(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def contact_address(client) do
     Deputy.request(client, :get, "/api/v1/my/contactaddress")
   end
@@ -95,7 +95,7 @@ defmodule Deputy.My do
       {:ok, [%{"Street1" => "123 Main St", "City" => "New York"}]}
 
   """
-  @spec all_contact_addresses(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec all_contact_addresses(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def all_contact_addresses(client) do
     Deputy.request(client, :get, "/api/v1/my/contactaddress/all")
   end
@@ -135,7 +135,7 @@ defmodule Deputy.My do
       {:ok, %{"success" => true}}
 
   """
-  @spec update_contact_address(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec update_contact_address(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def update_contact_address(client, attrs) do
     Deputy.request(client, :post, "/api/v1/my/contactaddress", body: attrs)
   end
@@ -150,7 +150,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 2, "FirstName" => "Jane", "LastName" => "Smith"}]}
 
   """
-  @spec colleagues(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec colleagues(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def colleagues(client) do
     Deputy.request(client, :get, "/api/v1/my/colleague")
   end
@@ -165,7 +165,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]}
 
   """
-  @spec rosters(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec rosters(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def rosters(client) do
     Deputy.request(client, :get, "/api/v1/my/roster")
   end
@@ -180,7 +180,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "DateStart" => "2023-01-01", "DateEnd" => "2023-01-05"}]}
 
   """
-  @spec leave(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec leave(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def leave(client) do
     Deputy.request(client, :get, "/api/v1/my/leave")
   end
@@ -195,7 +195,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "Start" => %{"timestamp" => 1657001675}}]}
 
   """
-  @spec unavailability(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec unavailability(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def unavailability(client) do
     Deputy.request(client, :get, "/api/v1/my/unavail")
   end
@@ -210,7 +210,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "Message" => "You have a new roster"}]}
 
   """
-  @spec notifications(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec notifications(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def notifications(client) do
     Deputy.request(client, :get, "/api/v1/my/notification")
   end
@@ -225,7 +225,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "Name" => "Safety Training"}]}
 
   """
-  @spec training(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec training(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def training(client) do
     Deputy.request(client, :get, "/api/v1/my/training")
   end
@@ -240,7 +240,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "Content" => "Welcome to Deputy"}]}
 
   """
-  @spec memos(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec memos(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def memos(client) do
     Deputy.request(client, :get, "/api/v1/my/memo")
   end
@@ -255,7 +255,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "TaskName" => "Complete training"}]}
 
   """
-  @spec tasks(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec tasks(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def tasks(client) do
     Deputy.request(client, :get, "/api/v1/my/tasks")
   end
@@ -275,7 +275,7 @@ defmodule Deputy.My do
       {:ok, %{"success" => true}}
 
   """
-  @spec complete_task(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec complete_task(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def complete_task(client, id) do
     Deputy.request(client, :get, "/api/v1/my/tasks/#{id}/do")
   end
@@ -290,7 +290,7 @@ defmodule Deputy.My do
       {:ok, [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]}
 
   """
-  @spec timesheets(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec timesheets(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def timesheets(client) do
     Deputy.request(client, :get, "/api/v1/my/timesheets")
   end
@@ -310,7 +310,7 @@ defmodule Deputy.My do
       {:ok, %{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}}
 
   """
-  @spec timesheet_detail(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec timesheet_detail(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def timesheet_detail(client, id) do
     Deputy.request(client, :get, "/api/v1/my/timesheets/#{id}/detail")
   end

--- a/lib/deputy/rosters.ex
+++ b/lib/deputy/rosters.ex
@@ -15,7 +15,7 @@ defmodule Deputy.Rosters do
       {:ok, [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]}
 
   """
-  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec list(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def list(client) do
     Deputy.request(client, :get, "/api/v1/supervise/roster")
   end
@@ -35,7 +35,7 @@ defmodule Deputy.Rosters do
       {:ok, %{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}}
 
   """
-  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/roster/#{id}")
   end
@@ -55,7 +55,7 @@ defmodule Deputy.Rosters do
       {:ok, [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]}
 
   """
-  @spec get_by_date(Deputy.t(), String.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_by_date(Deputy.t(), String.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_by_date(client, date) do
     params = %{date: date}
     Deputy.request(client, :get, "/api/v1/supervise/roster", params: params)
@@ -78,7 +78,7 @@ defmodule Deputy.Rosters do
 
   """
   @spec get_by_date_and_location(Deputy.t(), String.t(), integer()) ::
-          {:ok, list(map())} | {:error, any()}
+          {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_by_date_and_location(client, date, location_id) do
     params = %{date: date, intCompanyId: location_id}
     Deputy.request(client, :get, "/api/v1/supervise/roster", params: params)
@@ -112,7 +112,7 @@ defmodule Deputy.Rosters do
       {:ok, %{"success" => true}}
 
   """
-  @spec copy(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec copy(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def copy(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/roster/copy", body: attrs)
   end
@@ -143,7 +143,7 @@ defmodule Deputy.Rosters do
       {:ok, %{"success" => true}}
 
   """
-  @spec publish(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec publish(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def publish(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/roster/publish", body: attrs)
   end
@@ -170,7 +170,7 @@ defmodule Deputy.Rosters do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/roster/create", body: attrs)
   end
@@ -195,7 +195,7 @@ defmodule Deputy.Rosters do
       {:ok, %{"success" => true}}
 
   """
-  @spec discard(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec discard(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def discard(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/roster/discard", body: attrs)
   end
@@ -210,7 +210,7 @@ defmodule Deputy.Rosters do
       {:ok, [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]}
 
   """
-  @spec get_available_for_swap(Deputy.t()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_available_for_swap(Deputy.t()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_available_for_swap(client) do
     Deputy.request(client, :get, "/api/v1/supervise/roster/autobuild")
   end
@@ -230,7 +230,8 @@ defmodule Deputy.Rosters do
       {:ok, [%{"EmployeeId" => 123, "Score" => 85}]}
 
   """
-  @spec get_recommendations(Deputy.t(), integer()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_recommendations(Deputy.t(), integer()) ::
+          {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_recommendations(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/getRecommendation/#{id}")
   end

--- a/lib/deputy/sales.ex
+++ b/lib/deputy/sales.ex
@@ -44,7 +44,7 @@ defmodule Deputy.Sales do
       {:ok, %{"success" => true}}
 
   """
-  @spec add_metrics(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec add_metrics(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def add_metrics(client, metrics) do
     Deputy.request(client, :post, "/api/v2/metrics", body: metrics)
   end
@@ -77,7 +77,7 @@ defmodule Deputy.Sales do
       {:ok, [%{"timestamp" => 1626203600, "area" => 1, "type" => "Sales", "value" => 100.30}]}
 
   """
-  @spec get_metrics(Deputy.t(), map()) :: {:ok, list(map())} | {:error, any()}
+  @spec get_metrics(Deputy.t(), map()) :: {:ok, list(map())} | {:error, Deputy.Error.t()}
   def get_metrics(client, params) do
     Deputy.request(client, :get, "/api/v2/metrics/raw", params: params)
   end

--- a/lib/deputy/timesheets.ex
+++ b/lib/deputy/timesheets.ex
@@ -32,7 +32,7 @@ defmodule Deputy.Timesheets do
       {:ok, %{"Id" => 789}}
 
   """
-  @spec start(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec start(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def start(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/timesheet/start", body: attrs)
   end
@@ -61,7 +61,7 @@ defmodule Deputy.Timesheets do
       {:ok, %{"success" => true}}
 
   """
-  @spec stop(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec stop(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def stop(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/timesheet/end", body: attrs)
   end
@@ -86,7 +86,7 @@ defmodule Deputy.Timesheets do
       {:ok, %{"success" => true}}
 
   """
-  @spec pause(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec pause(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def pause(client, attrs) do
     Deputy.request(client, :post, "/api/v1/supervise/timesheet/pause", body: attrs)
   end
@@ -106,7 +106,7 @@ defmodule Deputy.Timesheets do
       {:ok, %{"Id" => 123, "StartTime" => "2023-01-01T09:00:00"}}
 
   """
-  @spec get_details(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get_details(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_details(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/timesheet/#{id}/details")
   end
@@ -136,7 +136,7 @@ defmodule Deputy.Timesheets do
 
   """
   @spec query(Deputy.t(), integer() | nil, map() | nil) ::
-          {:ok, map() | list(map())} | {:error, any()}
+          {:ok, map() | list(map())} | {:error, Deputy.Error.t()}
   def query(client, id, query \\ nil)
 
   def query(client, id, nil) when is_integer(id) do

--- a/lib/deputy/utility.ex
+++ b/lib/deputy/utility.ex
@@ -15,7 +15,7 @@ defmodule Deputy.Utility do
       {:ok, %{"time" => 1672531200, "tz" => "UTC"}}
 
   """
-  @spec get_time(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec get_time(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_time(client) do
     Deputy.request(client, :get, "/api/v1/time")
   end
@@ -35,7 +35,7 @@ defmodule Deputy.Utility do
       {:ok, %{"time" => 1672531200, "tz" => "America/New_York"}}
 
   """
-  @spec get_location_time(Deputy.t(), integer()) :: {:ok, map()} | {:error, any()}
+  @spec get_location_time(Deputy.t(), integer()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_location_time(client, location_id) do
     Deputy.request(client, :get, "/api/v1/time/#{location_id}")
   end
@@ -66,7 +66,7 @@ defmodule Deputy.Utility do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec create_memo(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec create_memo(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create_memo(client, attrs) do
     Deputy.request(client, :put, "/api/v1/supervise/memo", body: attrs)
   end
@@ -99,7 +99,7 @@ defmodule Deputy.Utility do
       {:ok, %{"Id" => 123}}
 
   """
-  @spec add_webhook(Deputy.t(), map()) :: {:ok, map()} | {:error, any()}
+  @spec add_webhook(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def add_webhook(client, attrs) do
     Deputy.request(client, :post, "/api/v1/resource/Webhook", body: attrs)
   end
@@ -114,7 +114,7 @@ defmodule Deputy.Utility do
       {:ok, %{"Id" => 1, "FirstName" => "John", "LastName" => "Doe"}}
 
   """
-  @spec who_am_i(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec who_am_i(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def who_am_i(client) do
     Deputy.request(client, :get, "/api/v1/me")
   end
@@ -129,7 +129,7 @@ defmodule Deputy.Utility do
       {:ok, %{"locations" => [%{"Id" => 1, "Name" => "Main Office"}]}}
 
   """
-  @spec get_setup(Deputy.t()) :: {:ok, map()} | {:error, any()}
+  @spec get_setup(Deputy.t()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def get_setup(client) do
     Deputy.request(client, :get, "/api/v1/my/setup")
   end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `RateLimitError.t()` to the `Deputy.Error.t()` union type — it was missing from the definition despite being a real error variant.
- Replace `{:error, any()}` with `{:error, Deputy.Error.t()}` in all resource module `@spec` annotations.
- Update `Deputy.request/4` and `Deputy.request!/4` to reflect that responses can be lists (`{:ok, map() | list()}`).

This enables Dialyzer to catch type mismatches at the boundary between callers and the library.

## Test plan

- [x] `mix test` passes
- [x] `mix format --check-formatted` passes