### PR TITLE
feat: add bang function variants to all resource modules

### DIFF
--- a/lib/deputy/departments.ex
+++ b/lib/deputy/departments.ex
@@ -165,4 +165,33 @@ defmodule Deputy.Departments do
   def query(client, query) do
     Deputy.request(client, :post, "/api/v1/resource/OperationalUnit/QUERY", body: query)
   end
+
+  @doc "Same as `create/2` but raises on error."
+  @spec create!(Deputy.t(), map()) :: map()
+  def create!(client, attrs),
+    do: Deputy.request!(client, :put, "/api/v1/supervise/department", body: attrs)
+
+  @doc "Same as `create_multiple/2` but raises on error."
+  @spec create_multiple!(Deputy.t(), map()) :: map()
+  def create_multiple!(client, attrs),
+    do: Deputy.request!(client, :put, "/api/v1/supervise/department/create/", body: attrs)
+
+  @doc "Same as `list/1` but raises on error."
+  @spec list!(Deputy.t()) :: list(map())
+  def list!(client), do: Deputy.request!(client, :get, "/api/v1/resource/OperationalUnit/")
+
+  @doc "Same as `delete/2` but raises on error."
+  @spec delete!(Deputy.t(), integer()) :: map()
+  def delete!(client, id),
+    do: Deputy.request!(client, :delete, "/api/v1/resource/OperationalUnit/#{id}")
+
+  @doc "Same as `update/3` but raises on error."
+  @spec update!(Deputy.t(), integer(), map()) :: map()
+  def update!(client, id, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/resource/OperationalUnit/#{id}", body: attrs)
+
+  @doc "Same as `query/2` but raises on error."
+  @spec query!(Deputy.t(), map()) :: list(map())
+  def query!(client, query),
+    do: Deputy.request!(client, :post, "/api/v1/resource/OperationalUnit/QUERY", body: query)
 end

--- a/lib/deputy/employees.ex
+++ b/lib/deputy/employees.ex
@@ -434,4 +434,105 @@ defmodule Deputy.Employees do
   def get_agreed_hours(client, id) do
     Deputy.request(client, :get, "/api/management/v2/agreed_hour/#{id}")
   end
+
+  @doc "Same as `list/1` but raises on error."
+  @spec list!(Deputy.t()) :: list(map())
+  def list!(client), do: Deputy.request!(client, :get, "/api/v1/supervise/employee")
+
+  @doc "Same as `get/2` but raises on error."
+  @spec get!(Deputy.t(), integer()) :: map()
+  def get!(client, id), do: Deputy.request!(client, :get, "/api/v1/supervise/employee/#{id}")
+
+  @doc "Same as `create/2` but raises on error."
+  @spec create!(Deputy.t(), map()) :: map()
+  def create!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee", body: attrs)
+
+  @doc "Same as `update/3` but raises on error."
+  @spec update!(Deputy.t(), integer(), map()) :: map()
+  def update!(client, id, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}", body: attrs)
+
+  @doc "Same as `add_location/3` but raises on error."
+  @spec add_location!(Deputy.t(), integer(), integer()) :: map()
+  def add_location!(client, employee_id, company_id),
+    do:
+      Deputy.request!(
+        client,
+        :post,
+        "/api/v1/supervise/employee/#{employee_id}/assoc/#{company_id}"
+      )
+
+  @doc "Same as `remove_location/3` but raises on error."
+  @spec remove_location!(Deputy.t(), integer(), integer()) :: map()
+  def remove_location!(client, employee_id, company_id),
+    do:
+      Deputy.request!(
+        client,
+        :post,
+        "/api/v1/supervise/employee/#{employee_id}/unassoc/#{company_id}"
+      )
+
+  @doc "Same as `terminate/2` but raises on error."
+  @spec terminate!(Deputy.t(), integer()) :: map()
+  def terminate!(client, id),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}/terminate")
+
+  @doc "Same as `reactivate/2` but raises on error."
+  @spec reactivate!(Deputy.t(), integer()) :: map()
+  def reactivate!(client, id),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}/activate")
+
+  @doc "Same as `delete/2` but raises on error."
+  @spec delete!(Deputy.t(), integer()) :: map()
+  def delete!(client, id),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}/delete")
+
+  @doc "Same as `invite/2` but raises on error."
+  @spec invite!(Deputy.t(), integer()) :: map()
+  def invite!(client, id),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}/invite")
+
+  @doc "Same as `set_award/3` but raises on error."
+  @spec set_award!(Deputy.t(), integer(), map()) :: map()
+  def set_award!(client, id, attrs),
+    do:
+      Deputy.request!(client, :post, "/api/v1/supervise/employee/#{id}/setAwardFromLibrary",
+        body: attrs
+      )
+
+  @doc "Same as `get_shift_info/2` but raises on error."
+  @spec get_shift_info!(Deputy.t(), integer()) :: map()
+  def get_shift_info!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/empshiftinfo/#{id}")
+
+  @doc "Same as `get_leave/2` but raises on error."
+  @spec get_leave!(Deputy.t(), integer()) :: list(map())
+  def get_leave!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/leave/#{id}")
+
+  @doc "Same as `add_leave/2` but raises on error."
+  @spec add_leave!(Deputy.t(), map()) :: map()
+  def add_leave!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/leave/", body: attrs)
+
+  @doc "Same as `get_unavailability/2` but raises on error."
+  @spec get_unavailability!(Deputy.t(), integer()) :: list(map())
+  def get_unavailability!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/unavail/#{id}")
+
+  @doc "Same as `add_unavailability/2` but raises on error."
+  @spec add_unavailability!(Deputy.t(), map()) :: map()
+  def add_unavailability!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/unavail/", body: attrs)
+
+  @doc "Same as `add_journal/2` but raises on error."
+  @spec add_journal!(Deputy.t(), map()) :: map()
+  def add_journal!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/journal", body: attrs)
+
+  @doc "Same as `get_agreed_hours/2` but raises on error."
+  @spec get_agreed_hours!(Deputy.t(), integer()) :: map()
+  def get_agreed_hours!(client, id),
+    do: Deputy.request!(client, :get, "/api/management/v2/agreed_hour/#{id}")
 end

--- a/lib/deputy/my.ex
+++ b/lib/deputy/my.ex
@@ -314,4 +314,80 @@ defmodule Deputy.My do
   def timesheet_detail(client, id) do
     Deputy.request(client, :get, "/api/v1/my/timesheets/#{id}/detail")
   end
+
+  @doc "Same as `me/1` but raises on error."
+  @spec me!(Deputy.t()) :: map()
+  def me!(client), do: Deputy.request!(client, :get, "/api/v1/me")
+
+  @doc "Same as `setup/1` but raises on error."
+  @spec setup!(Deputy.t()) :: map()
+  def setup!(client), do: Deputy.request!(client, :get, "/api/v1/my/setup")
+
+  @doc "Same as `locations/1` but raises on error."
+  @spec locations!(Deputy.t()) :: list(map())
+  def locations!(client), do: Deputy.request!(client, :get, "/api/v1/my/location")
+
+  @doc "Same as `location/2` but raises on error."
+  @spec location!(Deputy.t(), integer()) :: map()
+  def location!(client, id), do: Deputy.request!(client, :get, "/api/v1/my/location/#{id}")
+
+  @doc "Same as `contact_address/1` but raises on error."
+  @spec contact_address!(Deputy.t()) :: map()
+  def contact_address!(client), do: Deputy.request!(client, :get, "/api/v1/my/contactaddress")
+
+  @doc "Same as `all_contact_addresses/1` but raises on error."
+  @spec all_contact_addresses!(Deputy.t()) :: list(map())
+  def all_contact_addresses!(client),
+    do: Deputy.request!(client, :get, "/api/v1/my/contactaddress/all")
+
+  @doc "Same as `update_contact_address/2` but raises on error."
+  @spec update_contact_address!(Deputy.t(), map()) :: map()
+  def update_contact_address!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/my/contactaddress", body: attrs)
+
+  @doc "Same as `colleagues/1` but raises on error."
+  @spec colleagues!(Deputy.t()) :: list(map())
+  def colleagues!(client), do: Deputy.request!(client, :get, "/api/v1/my/colleague")
+
+  @doc "Same as `rosters/1` but raises on error."
+  @spec rosters!(Deputy.t()) :: list(map())
+  def rosters!(client), do: Deputy.request!(client, :get, "/api/v1/my/roster")
+
+  @doc "Same as `leave/1` but raises on error."
+  @spec leave!(Deputy.t()) :: list(map())
+  def leave!(client), do: Deputy.request!(client, :get, "/api/v1/my/leave")
+
+  @doc "Same as `unavailability/1` but raises on error."
+  @spec unavailability!(Deputy.t()) :: list(map())
+  def unavailability!(client), do: Deputy.request!(client, :get, "/api/v1/my/unavail")
+
+  @doc "Same as `notifications/1` but raises on error."
+  @spec notifications!(Deputy.t()) :: list(map())
+  def notifications!(client), do: Deputy.request!(client, :get, "/api/v1/my/notification")
+
+  @doc "Same as `training/1` but raises on error."
+  @spec training!(Deputy.t()) :: list(map())
+  def training!(client), do: Deputy.request!(client, :get, "/api/v1/my/training")
+
+  @doc "Same as `memos/1` but raises on error."
+  @spec memos!(Deputy.t()) :: list(map())
+  def memos!(client), do: Deputy.request!(client, :get, "/api/v1/my/memo")
+
+  @doc "Same as `tasks/1` but raises on error."
+  @spec tasks!(Deputy.t()) :: list(map())
+  def tasks!(client), do: Deputy.request!(client, :get, "/api/v1/my/tasks")
+
+  @doc "Same as `complete_task/2` but raises on error."
+  @spec complete_task!(Deputy.t(), integer()) :: map()
+  def complete_task!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/my/tasks/#{id}/do")
+
+  @doc "Same as `timesheets/1` but raises on error."
+  @spec timesheets!(Deputy.t()) :: list(map())
+  def timesheets!(client), do: Deputy.request!(client, :get, "/api/v1/my/timesheets")
+
+  @doc "Same as `timesheet_detail/2` but raises on error."
+  @spec timesheet_detail!(Deputy.t(), integer()) :: map()
+  def timesheet_detail!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/my/timesheets/#{id}/detail")
 end

--- a/lib/deputy/rosters.ex
+++ b/lib/deputy/rosters.ex
@@ -234,4 +234,55 @@ defmodule Deputy.Rosters do
   def get_recommendations(client, id) do
     Deputy.request(client, :get, "/api/v1/supervise/getRecommendation/#{id}")
   end
+
+  @doc "Same as `list/1` but raises on error."
+  @spec list!(Deputy.t()) :: list(map())
+  def list!(client), do: Deputy.request!(client, :get, "/api/v1/supervise/roster")
+
+  @doc "Same as `get/2` but raises on error."
+  @spec get!(Deputy.t(), integer()) :: map()
+  def get!(client, id), do: Deputy.request!(client, :get, "/api/v1/supervise/roster/#{id}")
+
+  @doc "Same as `get_by_date/2` but raises on error."
+  @spec get_by_date!(Deputy.t(), String.t()) :: list(map())
+  def get_by_date!(client, date),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/roster", params: %{date: date})
+
+  @doc "Same as `get_by_date_and_location/3` but raises on error."
+  @spec get_by_date_and_location!(Deputy.t(), String.t(), integer()) :: list(map())
+  def get_by_date_and_location!(client, date, location_id),
+    do:
+      Deputy.request!(client, :get, "/api/v1/supervise/roster",
+        params: %{date: date, intCompanyId: location_id}
+      )
+
+  @doc "Same as `copy/2` but raises on error."
+  @spec copy!(Deputy.t(), map()) :: map()
+  def copy!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/roster/copy", body: attrs)
+
+  @doc "Same as `publish/2` but raises on error."
+  @spec publish!(Deputy.t(), map()) :: map()
+  def publish!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/roster/publish", body: attrs)
+
+  @doc "Same as `create/2` but raises on error."
+  @spec create!(Deputy.t(), map()) :: map()
+  def create!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/roster/create", body: attrs)
+
+  @doc "Same as `discard/2` but raises on error."
+  @spec discard!(Deputy.t(), map()) :: map()
+  def discard!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/roster/discard", body: attrs)
+
+  @doc "Same as `get_available_for_swap/1` but raises on error."
+  @spec get_available_for_swap!(Deputy.t()) :: list(map())
+  def get_available_for_swap!(client),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/roster/autobuild")
+
+  @doc "Same as `get_recommendations/2` but raises on error."
+  @spec get_recommendations!(Deputy.t(), integer()) :: list(map())
+  def get_recommendations!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/getRecommendation/#{id}")
 end

--- a/lib/deputy/sales.ex
+++ b/lib/deputy/sales.ex
@@ -81,4 +81,14 @@ defmodule Deputy.Sales do
   def get_metrics(client, params) do
     Deputy.request(client, :get, "/api/v2/metrics/raw", params: params)
   end
+
+  @doc "Same as `add_metrics/2` but raises on error."
+  @spec add_metrics!(Deputy.t(), map()) :: map()
+  def add_metrics!(client, metrics),
+    do: Deputy.request!(client, :post, "/api/v2/metrics", body: metrics)
+
+  @doc "Same as `get_metrics/2` but raises on error."
+  @spec get_metrics!(Deputy.t(), map()) :: list(map())
+  def get_metrics!(client, params),
+    do: Deputy.request!(client, :get, "/api/v2/metrics/raw", params: params)
 end

--- a/lib/deputy/timesheets.ex
+++ b/lib/deputy/timesheets.ex
@@ -150,4 +150,37 @@ defmodule Deputy.Timesheets do
   def query(client, id, query) when is_integer(id) and is_map(query) do
     Deputy.request(client, :post, "/api/v1/resource/Timesheet/#{id}", body: query)
   end
+
+  @doc "Same as `start/2` but raises on error."
+  @spec start!(Deputy.t(), map()) :: map()
+  def start!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/timesheet/start", body: attrs)
+
+  @doc "Same as `stop/2` but raises on error."
+  @spec stop!(Deputy.t(), map()) :: map()
+  def stop!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/timesheet/end", body: attrs)
+
+  @doc "Same as `pause/2` but raises on error."
+  @spec pause!(Deputy.t(), map()) :: map()
+  def pause!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/supervise/timesheet/pause", body: attrs)
+
+  @doc "Same as `get_details/2` but raises on error."
+  @spec get_details!(Deputy.t(), integer()) :: map()
+  def get_details!(client, id),
+    do: Deputy.request!(client, :get, "/api/v1/supervise/timesheet/#{id}/details")
+
+  @doc "Same as `query/3` but raises on error."
+  @spec query!(Deputy.t(), integer() | nil, map() | nil) :: map() | list(map())
+  def query!(client, id, query \\ nil)
+
+  def query!(client, id, nil) when is_integer(id),
+    do: Deputy.request!(client, :get, "/api/v1/resource/Timesheet/#{id}")
+
+  def query!(client, nil, query) when is_map(query),
+    do: Deputy.request!(client, :post, "/api/v1/resource/Timesheet/QUERY", body: query)
+
+  def query!(client, id, query) when is_integer(id) and is_map(query),
+    do: Deputy.request!(client, :post, "/api/v1/resource/Timesheet/#{id}", body: query)
 end

--- a/lib/deputy/utility.ex
+++ b/lib/deputy/utility.ex
@@ -133,4 +133,31 @@ defmodule Deputy.Utility do
   def get_setup(client) do
     Deputy.request(client, :get, "/api/v1/my/setup")
   end
+
+  @doc "Same as `get_time/1` but raises on error."
+  @spec get_time!(Deputy.t()) :: map()
+  def get_time!(client), do: Deputy.request!(client, :get, "/api/v1/time")
+
+  @doc "Same as `get_location_time/2` but raises on error."
+  @spec get_location_time!(Deputy.t(), integer()) :: map()
+  def get_location_time!(client, location_id),
+    do: Deputy.request!(client, :get, "/api/v1/time/#{location_id}")
+
+  @doc "Same as `create_memo/2` but raises on error."
+  @spec create_memo!(Deputy.t(), map()) :: map()
+  def create_memo!(client, attrs),
+    do: Deputy.request!(client, :put, "/api/v1/supervise/memo", body: attrs)
+
+  @doc "Same as `add_webhook/2` but raises on error."
+  @spec add_webhook!(Deputy.t(), map()) :: map()
+  def add_webhook!(client, attrs),
+    do: Deputy.request!(client, :post, "/api/v1/resource/Webhook", body: attrs)
+
+  @doc "Same as `who_am_i/1` but raises on error."
+  @spec who_am_i!(Deputy.t()) :: map()
+  def who_am_i!(client), do: Deputy.request!(client, :get, "/api/v1/me")
+
+  @doc "Same as `get_setup/1` but raises on error."
+  @spec get_setup!(Deputy.t()) :: map()
+  def get_setup!(client), do: Deputy.request!(client, :get, "/api/v1/my/setup")
 end

--- a/test/deputy/departments_test.exs
+++ b/test/deputy/departments_test.exs
@@ -177,4 +177,22 @@ defmodule Deputy.DepartmentsTest do
       assert {:ok, ^response_body} = Deputy.Departments.query(client, query)
     end
   end
+
+  describe "list!/1" do
+    test "returns unwrapped list of departments", %{client: client} do
+      response_body = [%{"Id" => 1, "OpunitName" => "Sales"}]
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+
+        assert Keyword.get(opts, :url) ==
+                 "https://test.deputy.com/api/v1/resource/OperationalUnit/"
+
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Departments.list!(client)
+    end
+  end
 end

--- a/test/deputy/employees_test.exs
+++ b/test/deputy/employees_test.exs
@@ -404,4 +404,34 @@ defmodule Deputy.EmployeesTest do
       assert {:ok, ^response_body} = Deputy.Employees.get_agreed_hours(client, employee_id)
     end
   end
+
+  describe "list!/1" do
+    test "returns unwrapped list of employees", %{client: client} do
+      response_body = [%{"Id" => 1, "FirstName" => "John"}]
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v1/supervise/employee"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Employees.list!(client)
+    end
+  end
+
+  describe "get!/2" do
+    test "returns unwrapped employee by ID", %{client: client} do
+      response_body = %{"Id" => 1, "FirstName" => "John"}
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v1/supervise/employee/1"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Employees.get!(client, 1)
+    end
+  end
 end

--- a/test/deputy/my_test.exs
+++ b/test/deputy/my_test.exs
@@ -326,4 +326,19 @@ defmodule Deputy.MyTest do
       assert {:ok, ^response_body} = Deputy.My.timesheet_detail(client, timesheet_id)
     end
   end
+
+  describe "me!/1" do
+    test "returns unwrapped authenticated user info", %{client: client} do
+      response_body = %{"Id" => 1, "FirstName" => "John", "LastName" => "Doe"}
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v1/me"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.My.me!(client)
+    end
+  end
 end

--- a/test/deputy/rosters_test.exs
+++ b/test/deputy/rosters_test.exs
@@ -241,4 +241,19 @@ defmodule Deputy.RostersTest do
       assert {:ok, ^response_body} = Deputy.Rosters.get_recommendations(client, roster_id)
     end
   end
+
+  describe "list!/1" do
+    test "returns unwrapped list of rosters", %{client: client} do
+      response_body = [%{"Id" => 1, "StartTime" => "2023-01-01T09:00:00"}]
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v1/supervise/roster"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Rosters.list!(client)
+    end
+  end
 end

--- a/test/deputy/sales_test.exs
+++ b/test/deputy/sales_test.exs
@@ -74,4 +74,20 @@ defmodule Deputy.SalesTest do
       assert {:ok, ^response_body} = Deputy.Sales.get_metrics(client, params)
     end
   end
+
+  describe "get_metrics!/2" do
+    test "returns unwrapped metrics list", %{client: client} do
+      params = %{areas: "1", types: "Sales", start: "1626203567", end: "1657775576"}
+      response_body = [%{"timestamp" => 1_626_203_600, "type" => "Sales", "value" => 100.30}]
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v2/metrics/raw"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Sales.get_metrics!(client, params)
+    end
+  end
 end

--- a/test/deputy/timesheets_test.exs
+++ b/test/deputy/timesheets_test.exs
@@ -169,4 +169,23 @@ defmodule Deputy.TimesheetsTest do
       assert {:ok, ^response_body} = Deputy.Timesheets.query(client, timesheet_id, query)
     end
   end
+
+  describe "start!/2" do
+    test "returns unwrapped timesheet on start", %{client: client} do
+      attrs = %{intEmployeeId: 1, intCompanyId: 2}
+      response_body = %{"Id" => 789}
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :post
+
+        assert Keyword.get(opts, :url) ==
+                 "https://test.deputy.com/api/v1/supervise/timesheet/start"
+
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Timesheets.start!(client, attrs)
+    end
+  end
 end

--- a/test/deputy/utility_test.exs
+++ b/test/deputy/utility_test.exs
@@ -129,4 +129,19 @@ defmodule Deputy.UtilityTest do
       assert {:ok, ^response_body} = Deputy.Utility.get_setup(client)
     end
   end
+
+  describe "get_time!/1" do
+    test "returns unwrapped system time", %{client: client} do
+      response_body = %{"time" => 1_672_531_200, "tz" => "UTC"}
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn opts ->
+        assert Keyword.get(opts, :method) == :get
+        assert Keyword.get(opts, :url) == "https://test.deputy.com/api/v1/time"
+        {:ok, response_body}
+      end)
+
+      assert ^response_body = Deputy.Utility.get_time!(client)
+    end
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `!` variants for every public function in `Deputy.Employees`, `Deputy.Departments`, `Deputy.Rosters`, `Deputy.Timesheets`, `Deputy.Sales`, `Deputy.Utility`, and `Deputy.My`.
- Each bang function calls `Deputy.request!/4` directly, returning the unwrapped value or raising the appropriate error exception.
- Add representative bang function tests to each module's test file.

This makes the API surface consistent across the entire library — `Deputy.Locations` was the only module with bang functions before this change.

## Test plan

- [x] `mix test` passes (111 tests)
- [x] `mix format --check-formatted` passes