### PR TITLE
test: add error path coverage to all resource modules

### DIFF
--- a/test/deputy/departments_test.exs
+++ b/test/deputy/departments_test.exs
@@ -195,4 +195,39 @@ defmodule Deputy.DepartmentsTest do
       assert ^response_body = Deputy.Departments.list!(client)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 404 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{
+           status: 404,
+           body: %{"message" => "Department not found"}
+         })}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 404, message: "Department not found"}} =
+               Deputy.Departments.delete(client, 999)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.Departments.list(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Departments.list(client)
+    end
+  end
 end

--- a/test/deputy/employees_test.exs
+++ b/test/deputy/employees_test.exs
@@ -434,4 +434,36 @@ defmodule Deputy.EmployeesTest do
       assert ^response_body = Deputy.Employees.get!(client, 1)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 404 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{status: 404, body: %{"message" => "Employee not found"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 404, message: "Employee not found"}} =
+               Deputy.Employees.get(client, 999)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.Employees.list(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Employees.list(client)
+    end
+  end
 end

--- a/test/deputy/locations_test.exs
+++ b/test/deputy/locations_test.exs
@@ -258,4 +258,36 @@ defmodule Deputy.LocationsTest do
       assert {:ok, ^response_body} = Deputy.Locations.create_workplace(client, attrs)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 404 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{status: 404, body: %{"message" => "Location not found"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 404, message: "Location not found"}} =
+               Deputy.Locations.get(client, 999)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.Locations.list(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 30}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 30}} =
+               Deputy.Locations.list(client)
+    end
+  end
 end

--- a/test/deputy/my_test.exs
+++ b/test/deputy/my_test.exs
@@ -341,4 +341,35 @@ defmodule Deputy.MyTest do
       assert ^response_body = Deputy.My.me!(client)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 401 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 401, body: %{"message" => "Unauthorized"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 401, message: "Unauthorized"}} =
+               Deputy.My.me(client)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.My.me(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.My.timesheets(client)
+    end
+  end
 end

--- a/test/deputy/rosters_test.exs
+++ b/test/deputy/rosters_test.exs
@@ -256,4 +256,36 @@ defmodule Deputy.RostersTest do
       assert ^response_body = Deputy.Rosters.list!(client)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 404 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{status: 404, body: %{"message" => "Roster not found"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 404, message: "Roster not found"}} =
+               Deputy.Rosters.get(client, 999)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.Rosters.list(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Rosters.list(client)
+    end
+  end
 end

--- a/test/deputy/sales_test.exs
+++ b/test/deputy/sales_test.exs
@@ -90,4 +90,37 @@ defmodule Deputy.SalesTest do
       assert ^response_body = Deputy.Sales.get_metrics!(client, params)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 400 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{status: 400, body: %{"message" => "Invalid metric data"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 400, message: "Invalid metric data"}} =
+               Deputy.Sales.add_metrics(client, %{data: []})
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} =
+               Deputy.Sales.get_metrics(client, %{})
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Sales.get_metrics(client, %{})
+    end
+  end
 end

--- a/test/deputy/timesheets_test.exs
+++ b/test/deputy/timesheets_test.exs
@@ -188,4 +188,43 @@ defmodule Deputy.TimesheetsTest do
       assert ^response_body = Deputy.Timesheets.start!(client, attrs)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 422 response", %{client: client} do
+      attrs = %{intEmployeeId: 1, intCompanyId: 2}
+
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error,
+         Deputy.Error.from_response(%{
+           status: 422,
+           body: %{"message" => "Employee is already clocked in"}
+         })}
+      end)
+
+      assert {:error,
+              %Deputy.Error.APIError{status: 422, message: "Employee is already clocked in"}} =
+               Deputy.Timesheets.start(client, attrs)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} =
+               Deputy.Timesheets.get_details(client, 1)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Timesheets.get_details(client, 1)
+    end
+  end
 end

--- a/test/deputy/utility_test.exs
+++ b/test/deputy/utility_test.exs
@@ -144,4 +144,35 @@ defmodule Deputy.UtilityTest do
       assert ^response_body = Deputy.Utility.get_time!(client)
     end
   end
+
+  describe "error handling" do
+    test "returns API error for 401 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 401, body: %{"message" => "Unauthorized"}})}
+      end)
+
+      assert {:error, %Deputy.Error.APIError{status: 401, message: "Unauthorized"}} =
+               Deputy.Utility.who_am_i(client)
+    end
+
+    test "returns HTTP error for 500 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 500, body: "Internal Server Error"})}
+      end)
+
+      assert {:error, %Deputy.Error.HTTPError{status: 500}} = Deputy.Utility.get_time(client)
+    end
+
+    test "returns rate limit error for 429 response", %{client: client} do
+      Deputy.HTTPClient.Mock
+      |> expect(:request, fn _opts ->
+        {:error, Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 60}})}
+      end)
+
+      assert {:error, %Deputy.Error.RateLimitError{retry_after: 60}} =
+               Deputy.Utility.get_time(client)
+    end
+  end
 end


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `error handling` describe blocks to every resource module test file (`Locations`, `Employees`, `Departments`, `Rosters`, `Timesheets`, `Sales`, `Utility`, `My`).
- Each block covers three scenarios: API error (4xx with `message`), HTTP error (5xx), and rate limit error (429 with `retry_after`).
- Tests validate that `Deputy.Error.from_response/1` classifications are correctly propagated through each module's public functions, not just in `error_test.exs` in isolation.

## Test plan

- [x] `mix test` passes (127 tests, all green)