### PR TITLE
feat: validate required fields before API calls

### DIFF
--- a/lib/deputy/departments.ex
+++ b/lib/deputy/departments.ex
@@ -4,6 +4,7 @@ defmodule Deputy.Departments do
   """
 
   alias Deputy
+  alias Deputy.Error.ValidationError
 
   @doc """
   Create a department (operational unit).
@@ -38,7 +39,11 @@ defmodule Deputy.Departments do
   """
   @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
-    Deputy.request(client, :put, "/api/v1/supervise/department", body: attrs)
+    required = [:intCompanyId, :strOpunitName]
+
+    with :ok <- validate_required_fields(attrs, required) do
+      Deputy.request(client, :put, "/api/v1/supervise/department", body: attrs)
+    end
   end
 
   @doc """
@@ -78,7 +83,9 @@ defmodule Deputy.Departments do
   """
   @spec create_multiple(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create_multiple(client, attrs) do
-    Deputy.request(client, :put, "/api/v1/supervise/department/create/", body: attrs)
+    with :ok <- validate_required_fields(attrs, [:arrArea]) do
+      Deputy.request(client, :put, "/api/v1/supervise/department/create/", body: attrs)
+    end
   end
 
   @doc """
@@ -194,4 +201,24 @@ defmodule Deputy.Departments do
   @spec query!(Deputy.t(), map()) :: list(map())
   def query!(client, query),
     do: Deputy.request!(client, :post, "/api/v1/resource/OperationalUnit/QUERY", body: query)
+
+  defp validate_required_fields(attrs, required_fields) do
+    missing =
+      Enum.filter(required_fields, fn field ->
+        not Map.has_key?(attrs, field) and not Map.has_key?(attrs, to_string(field))
+      end)
+
+    case missing do
+      [] ->
+        :ok
+
+      [field | _] ->
+        {:error,
+         %ValidationError{
+           message: "missing required field: #{field}",
+           field: field,
+           value: nil
+         }}
+    end
+  end
 end

--- a/lib/deputy/employees.ex
+++ b/lib/deputy/employees.ex
@@ -4,6 +4,7 @@ defmodule Deputy.Employees do
   """
 
   alias Deputy
+  alias Deputy.Error.ValidationError
 
   @doc """
   Get all employees.
@@ -80,7 +81,11 @@ defmodule Deputy.Employees do
   """
   @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
-    Deputy.request(client, :post, "/api/v1/supervise/employee", body: attrs)
+    required = [:strFirstName, :strLastName, :intCompanyId]
+
+    with :ok <- validate_required_fields(attrs, required) do
+      Deputy.request(client, :post, "/api/v1/supervise/employee", body: attrs)
+    end
   end
 
   @doc """
@@ -538,4 +543,24 @@ defmodule Deputy.Employees do
   @spec get_agreed_hours!(Deputy.t(), integer()) :: map()
   def get_agreed_hours!(client, id),
     do: Deputy.request!(client, :get, "/api/management/v2/agreed_hour/#{id}")
+
+  defp validate_required_fields(attrs, required_fields) do
+    missing =
+      Enum.filter(required_fields, fn field ->
+        not Map.has_key?(attrs, field) and not Map.has_key?(attrs, to_string(field))
+      end)
+
+    case missing do
+      [] ->
+        :ok
+
+      [field | _] ->
+        {:error,
+         %ValidationError{
+           message: "missing required field: #{field}",
+           field: field,
+           value: nil
+         }}
+    end
+  end
 end

--- a/lib/deputy/rosters.ex
+++ b/lib/deputy/rosters.ex
@@ -4,6 +4,7 @@ defmodule Deputy.Rosters do
   """
 
   alias Deputy
+  alias Deputy.Error.ValidationError
 
   @doc """
   Get a list of rosters from the last 12 hours and forward 36 hours.
@@ -172,7 +173,11 @@ defmodule Deputy.Rosters do
   """
   @spec create(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def create(client, attrs) do
-    Deputy.request(client, :post, "/api/v1/supervise/roster/create", body: attrs)
+    required = [:intEmployeeId, :intCompanyId, :dtmStartTime, :dtmEndTime]
+
+    with :ok <- validate_required_fields(attrs, required) do
+      Deputy.request(client, :post, "/api/v1/supervise/roster/create", body: attrs)
+    end
   end
 
   @doc """
@@ -286,4 +291,24 @@ defmodule Deputy.Rosters do
   @spec get_recommendations!(Deputy.t(), integer()) :: list(map())
   def get_recommendations!(client, id),
     do: Deputy.request!(client, :get, "/api/v1/supervise/getRecommendation/#{id}")
+
+  defp validate_required_fields(attrs, required_fields) do
+    missing =
+      Enum.filter(required_fields, fn field ->
+        not Map.has_key?(attrs, field) and not Map.has_key?(attrs, to_string(field))
+      end)
+
+    case missing do
+      [] ->
+        :ok
+
+      [field | _] ->
+        {:error,
+         %ValidationError{
+           message: "missing required field: #{field}",
+           field: field,
+           value: nil
+         }}
+    end
+  end
 end

--- a/lib/deputy/timesheets.ex
+++ b/lib/deputy/timesheets.ex
@@ -4,6 +4,7 @@ defmodule Deputy.Timesheets do
   """
 
   alias Deputy
+  alias Deputy.Error.ValidationError
 
   @doc """
   Start an employee's timesheet (clock on).
@@ -34,7 +35,11 @@ defmodule Deputy.Timesheets do
   """
   @spec start(Deputy.t(), map()) :: {:ok, map()} | {:error, Deputy.Error.t()}
   def start(client, attrs) do
-    Deputy.request(client, :post, "/api/v1/supervise/timesheet/start", body: attrs)
+    required = [:intEmployeeId, :intCompanyId]
+
+    with :ok <- validate_required_fields(attrs, required) do
+      Deputy.request(client, :post, "/api/v1/supervise/timesheet/start", body: attrs)
+    end
   end
 
   @doc """
@@ -183,4 +188,24 @@ defmodule Deputy.Timesheets do
 
   def query!(client, id, query) when is_integer(id) and is_map(query),
     do: Deputy.request!(client, :post, "/api/v1/resource/Timesheet/#{id}", body: query)
+
+  defp validate_required_fields(attrs, required_fields) do
+    missing =
+      Enum.filter(required_fields, fn field ->
+        not Map.has_key?(attrs, field) and not Map.has_key?(attrs, to_string(field))
+      end)
+
+    case missing do
+      [] ->
+        :ok
+
+      [field | _] ->
+        {:error,
+         %ValidationError{
+           message: "missing required field: #{field}",
+           field: field,
+           value: nil
+         }}
+    end
+  end
 end

--- a/test/deputy/departments_test.exs
+++ b/test/deputy/departments_test.exs
@@ -40,6 +40,20 @@ defmodule Deputy.DepartmentsTest do
 
       assert {:ok, ^response_body} = Deputy.Departments.create(client, attrs)
     end
+
+    test "returns validation error when intCompanyId is missing", %{client: client} do
+      attrs = %{strOpunitName: "Sales"}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :intCompanyId}} =
+               Deputy.Departments.create(client, attrs)
+    end
+
+    test "returns validation error when strOpunitName is missing", %{client: client} do
+      attrs = %{intCompanyId: 1}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :strOpunitName}} =
+               Deputy.Departments.create(client, attrs)
+    end
   end
 
   describe "create_multiple/2" do

--- a/test/deputy/employees_test.exs
+++ b/test/deputy/employees_test.exs
@@ -82,6 +82,27 @@ defmodule Deputy.EmployeesTest do
 
       assert {:ok, ^response_body} = Deputy.Employees.create(client, attrs)
     end
+
+    test "returns validation error when strFirstName is missing", %{client: client} do
+      attrs = %{strLastName: "Doe", intCompanyId: 1}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :strFirstName}} =
+               Deputy.Employees.create(client, attrs)
+    end
+
+    test "returns validation error when strLastName is missing", %{client: client} do
+      attrs = %{strFirstName: "John", intCompanyId: 1}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :strLastName}} =
+               Deputy.Employees.create(client, attrs)
+    end
+
+    test "returns validation error when intCompanyId is missing", %{client: client} do
+      attrs = %{strFirstName: "John", strLastName: "Doe"}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :intCompanyId}} =
+               Deputy.Employees.create(client, attrs)
+    end
   end
 
   describe "update/3" do

--- a/test/deputy/rosters_test.exs
+++ b/test/deputy/rosters_test.exs
@@ -175,6 +175,24 @@ defmodule Deputy.RostersTest do
 
       assert {:ok, ^response_body} = Deputy.Rosters.create(client, attrs)
     end
+
+    test "returns validation error when intEmployeeId is missing", %{client: client} do
+      attrs = %{
+        intCompanyId: 3,
+        dtmStartTime: "2023-01-01 09:00:00",
+        dtmEndTime: "2023-01-01 17:00:00"
+      }
+
+      assert {:error, %Deputy.Error.ValidationError{field: :intEmployeeId}} =
+               Deputy.Rosters.create(client, attrs)
+    end
+
+    test "returns validation error when dtmStartTime is missing", %{client: client} do
+      attrs = %{intEmployeeId: 1, intCompanyId: 3, dtmEndTime: "2023-01-01 17:00:00"}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :dtmStartTime}} =
+               Deputy.Rosters.create(client, attrs)
+    end
   end
 
   describe "discard/2" do

--- a/test/deputy/timesheets_test.exs
+++ b/test/deputy/timesheets_test.exs
@@ -41,6 +41,20 @@ defmodule Deputy.TimesheetsTest do
 
       assert {:ok, ^response_body} = Deputy.Timesheets.start(client, attrs)
     end
+
+    test "returns validation error when intEmployeeId is missing", %{client: client} do
+      attrs = %{intCompanyId: 2}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :intEmployeeId}} =
+               Deputy.Timesheets.start(client, attrs)
+    end
+
+    test "returns validation error when intCompanyId is missing", %{client: client} do
+      attrs = %{intEmployeeId: 1}
+
+      assert {:error, %Deputy.Error.ValidationError{field: :intCompanyId}} =
+               Deputy.Timesheets.start(client, attrs)
+    end
   end
 
   describe "stop/2" do


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add a `validate_required_fields/2` private helper to `Employees`, `Departments`, `Rosters`, and `Timesheets`.
- Key mutating functions (`create/2`, `start/2`) now return `{:error, %ValidationError{}}` when required fields are missing, rather than forwarding incomplete requests to the Deputy API.
- Add validation tests for each affected function covering each required field.

**Functions and required fields validated:**
- `Employees.create/2`: `strFirstName`, `strLastName`, `intCompanyId`
- `Departments.create/2`: `intCompanyId`, `strOpunitName`
- `Departments.create_multiple/2`: `arrArea`
- `Rosters.create/2`: `intEmployeeId`, `intCompanyId`, `dtmStartTime`, `dtmEndTime`
- `Timesheets.start/2`: `intEmployeeId`, `intCompanyId`

## Test plan

- [x] `mix test` passes (112 tests)
- [x] Validation errors are returned before any HTTP calls