### PR TITLE
docs: add release-please version markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ organized by resource type.
 This package can be installed by adding `deputy` to your list of dependencies in
 `mix.exs`:
 
+<!-- x-release-please-start-version -->
 ```elixir
 def deps do
   [
@@ -18,6 +19,7 @@ def deps do
   ]
 end
 ```
+<!-- x-release-please-end -->
 
 ## Getting Started
 


### PR DESCRIPTION
💁 These changes add [Release Please](https://github.com/googleapis/release-please) version markers around the installation example, which enables this version to be updated as part of a new release.