### PR TITLE
test: enable doctest execution for Deputy.Error

### DIFF
--- a/lib/deputy/error.ex
+++ b/lib/deputy/error.ex
@@ -117,6 +117,21 @@ defmodule Deputy.Error do
 
   This function analyzes the HTTP response and creates a specific error struct
   based on the status code and response body structure.
+
+  ## Examples
+
+      iex> Deputy.Error.from_response(%{status: 404, body: %{"message" => "Not found"}})
+      %Deputy.Error.APIError{status: 404, code: nil, message: "Not found", details: %{}}
+
+      iex> Deputy.Error.from_response(%{status: 429, body: %{"retry_after" => 30}})
+      %Deputy.Error.RateLimitError{retry_after: 30, limit: nil, remaining: nil}
+
+      iex> Deputy.Error.from_response(%{status: 500, body: "Server error"})
+      %Deputy.Error.HTTPError{reason: "Server error", status: 500, body: "Server error"}
+
+      iex> Deputy.Error.from_response(:timeout)
+      %Deputy.Error.HTTPError{reason: :timeout, status: nil, body: nil}
+
   """
   @spec from_response(map()) :: t()
   def from_response(%{status: 429, body: body}) do

--- a/test/deputy/error_test.exs
+++ b/test/deputy/error_test.exs
@@ -1,5 +1,6 @@
 defmodule Deputy.ErrorTest do
   use ExUnit.Case, async: true
+  doctest Deputy.Error
 
   alias Deputy.Error
   alias Deputy.Error.{APIError, HTTPError, ParseError, RateLimitError, ValidationError}


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Add `iex>` examples to `Deputy.Error.from_response/1` covering the four main response classifications: API error (4xx with message), rate limit (429), HTTP error (5xx), and transport error (atom).
- Enable `doctest Deputy.Error` in `error_test.exs` so those examples are verified on every test run.

The resource module functions all make HTTP calls, so their `@doc` examples cannot be run as doctests without significant restructuring. The `from_response/1` function is a pure transformation and is the highest-value pure function in the codebase to cover with doctests.

## Test plan

- [x] `mix test` passes with 5 doctests (1 existing from `Deputy.new/1`, 4 new)