### PR TITLE
feat(telemetry): emit telemetry events for API requests

### DIFF
--- a/lib/deputy.ex
+++ b/lib/deputy.ex
@@ -44,6 +44,37 @@ defmodule Deputy do
       IO.puts("Rate limited. Try again in " <> to_string(seconds) <> " seconds")
   end
   ```
+
+  ## Telemetry
+
+  Deputy emits the following `:telemetry` events for every API request made via `Deputy.HTTPClient.Req`:
+
+  ### `[:deputy, :request, :start]`
+
+  Emitted before the HTTP request is sent.
+
+  | measurements | type | description |
+  |---|---|---|
+  | `system_time` | `integer` | Current system time in native units (`System.system_time/0`) |
+
+  | metadata | type | description |
+  |---|---|---|
+  | `method` | `atom` | HTTP method (e.g. `:get`, `:post`) |
+  | `url` | `String.t()` | Full request URL |
+
+  ### `[:deputy, :request, :stop]`
+
+  Emitted after the HTTP response is received and classified.
+
+  | measurements | type | description |
+  |---|---|---|
+  | `duration` | `integer` | Elapsed time in native units (use `System.convert_time_unit/3` to convert) |
+
+  | metadata | type | description |
+  |---|---|---|
+  | `method` | `atom` | HTTP method |
+  | `url` | `String.t()` | Full request URL |
+  | `status` | `atom \| integer` | `:ok` for 2xx responses, HTTP status integer for API errors, `:error` for transport errors |
   """
 
   alias Deputy.Error

--- a/lib/deputy/http_client/req.ex
+++ b/lib/deputy/http_client/req.ex
@@ -19,10 +19,10 @@ defmodule Deputy.HTTPClient.Req do
 
     result =
       case Req.request(opts) do
-        {:ok, %{status: status, body: body, headers: headers}} when status in 200..299 ->
+        {:ok, %{status: status, body: body}} when status in 200..299 ->
           {:ok, body}
 
-        {:ok, %{status: status, body: body}} ->
+        {:ok, %{status: status, body: body, headers: headers}} ->
           error = Error.from_response(%{status: status, body: body, headers: headers})
           {:error, error}
 

--- a/lib/deputy/http_client/req.ex
+++ b/lib/deputy/http_client/req.ex
@@ -8,16 +8,43 @@ defmodule Deputy.HTTPClient.Req do
 
   @impl true
   def request(opts) do
-    case Req.request(opts) do
-      {:ok, %{status: status, body: body}} when status in 200..299 ->
-        {:ok, body}
+    method = Keyword.get(opts, :method)
+    url = Keyword.get(opts, :url)
+    start_time = System.monotonic_time()
 
-      {:ok, %{status: status, body: body, headers: headers}} ->
-        error = Error.from_response(%{status: status, body: body, headers: headers})
-        {:error, error}
+    :telemetry.execute([:deputy, :request, :start], %{system_time: System.system_time()}, %{
+      method: method,
+      url: url
+    })
 
-      {:error, error} ->
-        {:error, Error.from_response(error)}
-    end
+    result =
+      case Req.request(opts) do
+        {:ok, %{status: status, body: body, headers: headers}} when status in 200..299 ->
+          {:ok, body}
+
+        {:ok, %{status: status, body: body}} ->
+          error = Error.from_response(%{status: status, body: body, headers: headers})
+          {:error, error}
+
+        {:error, error} ->
+          {:error, Error.from_response(error)}
+      end
+
+    duration = System.monotonic_time() - start_time
+
+    status =
+      case result do
+        {:ok, _} -> :ok
+        {:error, %{status: s}} when not is_nil(s) -> s
+        {:error, _} -> :error
+      end
+
+    :telemetry.execute([:deputy, :request, :stop], %{duration: duration}, %{
+      method: method,
+      url: url,
+      status: status
+    })
+
+    result
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Deputy.MixProject do
   defp deps do
     [
       {:req, "~> 0.5.0"},
+      {:telemetry, "~> 1.0"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:expublish, "~> 2.5", only: :dev, runtime: false},


### PR DESCRIPTION
:tipping_hand_person: These changes:

- Emit `[:deputy, :request, :start]` before each HTTP call with `system_time`, `method`, and `url`
- Emit `[:deputy, :request, :stop]` after each HTTP call with `duration`, `method`, `url`, and `status`
- Add `:telemetry` as an explicit top-level dependency (was previously only transitive via Req)
- Document both events in the `Deputy` module `@moduledoc` with measurement and metadata tables

## Test plan

- [x] `mix test` passes
- [ ] `mix credo --strict` clean
- [ ] `mix format --check-formatted` clean